### PR TITLE
Using resolved PokemonName slot value instead of raw value

### DIFF
--- a/src/handlers/LookupByNameIntentHandler.ts
+++ b/src/handlers/LookupByNameIntentHandler.ts
@@ -24,7 +24,13 @@ export class LookupByNameIntentHandler extends RequestHandlerBase {
             throw "Invalid IntentRequest";
         }
 
-        const pokemonName: string | undefined = intentRequest.intent.slots["PokemonName"].value;
+        const slot = intentRequest.intent.slots["PokemonName"];
+        let pokemonName: string | undefined = slot.value;
+        if (slot && slot.resolutions && slot.resolutions.resolutionsPerAuthority && slot.resolutions.resolutionsPerAuthority[0] && slot.resolutions.resolutionsPerAuthority[0].values) {
+            // Use resolved value if one is available
+            pokemonName = slot.resolutions.resolutionsPerAuthority[0].values[0].value.name;
+        }
+
         if (!pokemonName) {
             return responseBuilder
                 .speak("Couldn't find that one!")


### PR DESCRIPTION
Updating LookupByNameIntentHandler to use the first resolved value
for the PokemonName slot instead of the raw value that does not
necessarily match one of our expected values for the slot.
This will fix issues where the value contains an unexpected accent
character or some other inconsistency the causes data retrieval to fail.