### PR TITLE
Randomizing Pokemon descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     "devDependencies": {
         "@types/jest": "^24.0.18",
-        "@types/node": "^12.7.12",
+        "@types/node": "^13.7.1",
         "@typescript-eslint/eslint-plugin": "^2.3.3",
         "@typescript-eslint/parser": "^2.3.3",
         "dts-gen": "^0.5.8",

--- a/src/handlers/LookupByNameIntentHandler.ts
+++ b/src/handlers/LookupByNameIntentHandler.ts
@@ -38,9 +38,13 @@ export class LookupByNameIntentHandler extends RequestHandlerBase {
                 .getResponse();
         }
 
+        // Retrieve the Pokemon with the given name
         const pokemon: Pokemon = await this.database.GetPokemonByName(pokemonName);
         
-        const description: string = pokemon.Descriptions[0];
+        // Get a random description from the available set
+        const description: string = pokemon.Descriptions[Math.floor(Math.random() * pokemon.Descriptions.length)];
+
+        // E.g. "Tiny Turtle Pokemon"
         const genus: string = pokemon.Genus;
 
         const speech = `${pokemon.Name}: the ${genus}. ${description}`;

--- a/src/handlers/LookupByNumberIntentHandler.ts
+++ b/src/handlers/LookupByNumberIntentHandler.ts
@@ -24,17 +24,21 @@ export class LookupByNumberIntentHandler extends RequestHandlerBase {
             throw "Invalid IntentRequest";
         }
 
-        const pokemonName: string | undefined = intentRequest.intent.slots["Number"].value;
-        if (!pokemonName) {
+        const pokemonNumber: string | undefined = intentRequest.intent.slots["Number"].value;
+        if (!pokemonNumber) {
             return responseBuilder
                 .speak("Couldn't find that one!")
                 .withShouldEndSession(true)
                 .getResponse();
         }
 
-        const pokemon: Pokemon = await this.database.GetPokemonByName(pokemonName);
+        // Retrieve the Pokemon with the given name
+        const pokemon: Pokemon = await this.database.GetPokemonByNumber(parseInt(pokemonNumber));
         
-        const description: string = pokemon.Descriptions[0];
+        // Get a random description from the available set
+        const description: string = pokemon.Descriptions[Math.floor(Math.random() * pokemon.Descriptions.length)];
+
+        // E.g. "Tiny Turtle Pokemon"
         const genus: string = pokemon.Genus;
 
         return responseBuilder

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,10 +361,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
-"@types/node@^12.7.12":
-  version "12.7.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.12.tgz#7c6c571cc2f3f3ac4a59a5f2bd48f5bdbc8653cc"
-  integrity sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==
+"@types/node@^13.7.1":
+  version "13.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.1.tgz#238eb34a66431b71d2aaddeaa7db166f25971a0d"
+  integrity sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
Updating intent handlers to serve up random descriptions instead of
always returning the first one.
Adding typings package for node.
Fixing issue where wrong logic was executed by LookupByNumberIntentHandler.